### PR TITLE
Feature/paginate time entries

### DIFF
--- a/src/Rossedman/Teamwork/Time.php
+++ b/src/Rossedman/Teamwork/Time.php
@@ -11,7 +11,7 @@ class Time extends AbstractObject {
     protected $endpoint = 'time_entries';
 
     /**
-     * GET /time.json
+     * GET /time_entries.json
      *
      * @return mixed
      */

--- a/src/Rossedman/Teamwork/Time.php
+++ b/src/Rossedman/Teamwork/Time.php
@@ -10,4 +10,15 @@ class Time extends AbstractObject {
 
     protected $endpoint = 'time_entries';
 
+    /**
+     * GET /time.json
+     *
+     * @return mixed
+     */
+    public function all($args = null)
+    {
+        $this->areArgumentsValid($args, ['page']);
+
+        return $this->client->get($this->endpoint, $args)->response();
+    }
 }


### PR DESCRIPTION
This pull request adds in the all() function to the time class so that we can paginate through time entries. Can be used in the following way:

```
$time = \Teamwork::time()->all(['page' => $pageNo]);
```
