### PR TITLE
Added an authenticate class to get user data using the special teamwork URL

### DIFF
--- a/src/Rossedman/Teamwork/Authenticate.php
+++ b/src/Rossedman/Teamwork/Authenticate.php
@@ -1,0 +1,18 @@
+<?php  namespace Rossedman\Teamwork;
+
+class Authenticate extends AbstractObject {
+
+    protected $url = "https://authenticate.teamworkpm.net/authenticate.json";
+
+    /**
+     * Authenticate Details
+     * GET https://authenticate.teamworkpm.net/authenticate.json
+     *
+     * @link http://developer.teamwork.com/account#the_'authenti
+     * @return mixed
+     */
+    public function authenticate()
+    {
+        return $this->client->get($this->url)->response();
+    }
+}

--- a/src/Rossedman/Teamwork/Client.php
+++ b/src/Rossedman/Teamwork/Client.php
@@ -172,6 +172,11 @@ class Client implements RequestableInterface {
      */
     public function buildUrl($endpoint)
     {
+        if (filter_var($endpoint, FILTER_VALIDATE_URL))
+        {
+            return $this->url . '.' . $this->dataFormat;
+        }
+
         if (substr($this->url, -1) != '/')
         {
             $this->url = $this->url . '/';

--- a/src/Rossedman/Teamwork/Client.php
+++ b/src/Rossedman/Teamwork/Client.php
@@ -174,7 +174,7 @@ class Client implements RequestableInterface {
     {
         if (filter_var($endpoint, FILTER_VALIDATE_URL))
         {
-            return $this->url . '.' . $this->dataFormat;
+            return $endpoint . '.' . $this->dataFormat;
         }
 
         if (substr($this->url, -1) != '/')

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -59,4 +59,18 @@ class ClientTest extends PHPUnit_Framework_TestCase {
 
         $this->assertEquals('http://teamwork.com/test.json', $url);
     }
+
+    /**
+     * @group client
+     */
+    public function test_build_url_with_full_url()
+    {
+        $url = 'http://teamwork.com/authenticate/test/url';
+        $expectedUrl = $url . '.json';
+        $client = new Client($this->guzzle, 'key', 'http://teamwork.com');
+
+        $actualUrl = $client->buildUrl($url);
+
+        $this->assertEquals($expectedUrl, $actualUrl);
+    }
 }


### PR DESCRIPTION
Added ability to use the special teamwork URL to find out a users details so we can set the users URL automatically if needed:

```
$client     = new Client(new Guzzle, 'Cheese999Burger', '');
$teamwork   = new Teamwork($client);
$account = $teamwork->authenticate()->authenticate();
if (empty($account)) {
    return 'Bad API Key';
}

print_r($account); //$account['account']['URL'] has the users teamwork URL in it
```
