### PR TITLE
Change 'share' method in service provider to 'singleton' to support L5.4

### DIFF
--- a/src/Rossedman/Teamwork/TeamworkServiceProvider.php
+++ b/src/Rossedman/Teamwork/TeamworkServiceProvider.php
@@ -12,7 +12,7 @@ class TeamworkServiceProvider extends ServiceProvider {
      */
     public function register()
     {
-        $this->app['rossedman.teamwork'] = $this->app->share(function($app)
+        $this->app->singleton('rossedman.teamwork', function($app)
         {
             $client = new \Rossedman\Teamwork\Client(new Guzzle,
                 $app['config']->get('services.teamwork.key'),


### PR DESCRIPTION
Laravel 5.4 [dropped support](https://laravel.com/docs/5.4/upgrade) for `share()`. I have updated the TeamworkServiceProvider to use `singleton()` instead of `share()`

I've included a snippet from the upgrade guide below to save you hunting through the page for it 👌 

> The share method has been removed from the container. This was a legacy method that has not been documented in several years. If you are using this method, you should begin using the  singleton method instead