### PR TITLE
Removed .json extension to url for Task Edit

### DIFF
--- a/src/Rossedman/Teamwork/Task.php
+++ b/src/Rossedman/Teamwork/Task.php
@@ -67,6 +67,6 @@ class Task extends AbstractObject {
      */
     public function edit($args)
     {
-        return $this->client->put("$this->endpoint/$this->id.json", ['todo-item' => $args])->response();
+        return $this->client->put("$this->endpoint/$this->id", ['todo-item' => $args])->response();
     }
 }


### PR DESCRIPTION
The .json extension is already added by the Client class (buildUrl).
This end up adding 2 .json extension to url.